### PR TITLE
Build a flake with proper cross compiling support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,33 @@ jobs:
     - uses: actions/checkout@v2
     - name: Format
       run: find src include test -iregex '.*\.\(c\|h\|cpp\|hpp\|cc\|hh\|cxx\|hxx\)$' | xargs clang-format -n -Werror
+  build-nix:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v15
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: Build and test
+      run: nix build -L
+  build-nix-mac:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v15
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: Build and test
+      run: nix build -L
+  build-nix-cross:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v15
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: Build and test
+      run: nix build -L .\#crossPackage.x86_64-linux
   build-linux:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+/result
 libs
 cmake-build-*
 .idea

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1655707439,
+        "narHash": "sha256-pLQHpTFguAtlpKA/iXw4EYKvTUKj4pAa3I/XYf8Yi1U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c8f6b47ac9ed1e9b7f4672ef108299c8d4046a3f",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "master",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "UPPAAL Utility Library";
+
+  inputs.nixpkgs.url = "nixpkgs/master";
+
+  outputs = { self, nixpkgs }:
+    let
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+      crossNixpkgsFor = forAllSystems (system: import nixpkgs {
+        inherit system;
+        crossSystem = nixpkgs.lib.systems.examples.mingwW64;
+      });
+    in
+    {
+
+      # Adds a cross compiling check to package if it is built for a MinGW target
+      addCrossCheck = (pkgs: nativePkgs: dv: if !pkgs.stdenv.targetPlatform.isMinGW then dv else
+      dv.overrideAttrs (oldAttrs: rec {
+        cmakeFlags = oldAttrs.cmakeFlags ++ [ "-DCMAKE_TOOLCHAIN_FILE=toolchains/mingw.cmake" ];
+
+        # Add the wine64 package, and a script wine, which just execs wine64
+        nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ (nativePkgs.writeShellScriptBin "wine" "exec ${nativePkgs.wine64Packages.stableFull}/bin/wine64 $@") ];
+
+        # Adds an extra build phase, which runs tests using Wine
+        postPhases = [ "crossCheck" ];
+        crossCheck = "
+        # Wine needs a home directory to put some stuff in
+        HOME=$(mktemp -d);
+
+          # Add required DLLS to WINEPATH
+          export WINEPATH=\"$WINEPATH;$(dirname $(PATH=$PATH:$($CC -print-search-dirs | ${nativePkgs.ripgrep}/bin/rg 'libraries: =' | sed 's/libraries: =//g') ${nativePkgs.which}/bin/which libgcc_s_seh-1.dll))\";
+          export WINEPATH=\"$WINEPATH;${pkgs.windows.mcfgthreads}/bin\";
+          ctest --output-on-failure";
+      }));
+
+      library = (pkgs: nativePkgs:
+        self.addCrossCheck pkgs nativePkgs (pkgs.stdenv.mkDerivation {
+          pname = "UUtils";
+          version = "1.0.0";
+          src = ./.;
+          nativeBuildInputs = with nativePkgs; [ cmake ];
+          buildInputs = with pkgs; [ doctest boost174 ];
+          propagatedBuildInputs = with pkgs; [ xxHash ];
+          cmakeFlags = [ "-DTESTING=ON" ];
+
+          doCheck = true;
+        }));
+
+      defaultPackage = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        self.library pkgs pkgs);
+
+
+      crossPackage = forAllSystems (system:
+        let
+          nativePkgs = nixpkgsFor.${system};
+          pkgs = crossNixpkgsFor.${system};
+        in
+        (self.library pkgs nativePkgs));
+
+    };
+}

--- a/toolchains/mingw.cmake
+++ b/toolchains/mingw.cmake
@@ -1,5 +1,7 @@
 # the name of the target operating system
 set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_CROSSCOMPILING ON)
+set(CMAKE_CROSSCOMPILING_EMULATOR wine)
 
 # which compilers to use for C and C++
 set(CMAKE_C_COMPILER   x86_64-w64-mingw32-gcc)


### PR DESCRIPTION
Also uses the new cmake xxhash. The utility function addCrossCheck can
be used by flakes that depend on our flake, to add a check phase to a
derivation that uses wine.

This also fixes the wine tests that broke in the CI recently for all our other repos.

When this is merged, I can add a corresponding flake to UDBM, and then UCDD, and so on.