### PR TITLE
Update boost to 1.86 and other small build system fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Version of clang-format
@@ -18,7 +18,7 @@ jobs:
       - name: Formatting
         run: find src include test -iregex '.*\.\(c\|h\|cpp\|hpp\|cc\|hh\|cxx\|hxx\)$' | xargs clang-format -n -Werror
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       TARGET: x86_64-linux
       CMAKE_GENERATOR: Ninja
@@ -45,7 +45,7 @@ jobs:
           ctest --test-dir "$BUILD" -C $CMAKE_BUILD_TYPE
 
   build-win:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       TARGET: x86_64-w64-mingw32
       WINARCH: win64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
           pwsh -Command { $env:CMAKE_BUILD_TYPE=Release; bash ./getlibs.sh x86_64-w64-mingw32 }
       - name: Build
         run: |
-          $env:BUILD=build-x86_64-windows-debug'
+          $env:BUILD='build-x86_64-windows-debug'
           cmake -S . -B $env:BUILD -DCMAKE_PREFIX_PATH=${{ github.workspace }}/local/x86_64-w64-mingw32
           cmake --build $env:BUILD --config $env:CMAKE_BUILD_TYPE
           ctest --test-dir $env:BUILD -C $env:CMAKE_BUILD_TYPE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,24 +29,18 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install compiler tools
         run: |
-          sudo apt-get -qy update
-          sudo apt-get -qy install cmake ninja-build
+          sudo apt-get -qq update
+          sudo apt-get -qq install g++ cmake ninja-build
           CORES=$(nproc)
           echo "CMAKE_BUILD_PARALLEL_LEVEL=$CORES" >> $GITHUB_ENV
           echo "CTEST_PARALLEL_LEVEL=$CORES" >> $GITHUB_ENV
-      - name: Build without getlibs
-        run: |
-          BUILD=build-x86_64-linux-debug
-          cmake -S . -B "$BUILD" -DUBSAN=ON
-          cmake --build "$BUILD" --config $CMAKE_BUILD_TYPE
-          ctest --test-dir "$BUILD" -C $CMAKE_BUILD_TYPE
-      - name: Get dependencies
+      - name: Get Libs
         run: |
           CMAKE_BUILD_TYPE=Release ./getlibs.sh $TARGET
-      - name: Build with getlibs
+      - name: Build
         run: |
-          BUILD=build-${TARGET}-libs-${CMAKE_BUILD_TYPE,,}
-          cmake -S . -B "$BUILD" -DCMAKE_PREFIX_PATH="$PWD/local/$TARGET" -DUBSAN=ON -DFIND_FATAL=ON
+          BUILD=build-${TARGET}-${CMAKE_BUILD_TYPE,,}
+          cmake -S . -B "$BUILD" -DCMAKE_PREFIX_PATH="$PWD/local/${TARGET}" -DUBSAN=ON -DASAN=ON -DFIND_FATAL=ON
           cmake --build "$BUILD" --config $CMAKE_BUILD_TYPE
           ctest --test-dir "$BUILD" -C $CMAKE_BUILD_TYPE
 
@@ -64,8 +58,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install cross-compiler tools
         run: |
-          sudo apt-get -qy update
-          sudo apt-get -qy install cmake ninja-build g++-mingw-w64-x86-64 mingw-w64-x86-64-dev mingw-w64-tools wine wine-binfmt
+          sudo apt-get -qq update
+          sudo apt-get -qq install cmake ninja-build g++-mingw-w64-x86-64 mingw-w64-x86-64-dev mingw-w64-tools wine wine-binfmt
           sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
           sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
           WINEPATH=$(./winepath-for $TARGET)
@@ -74,19 +68,13 @@ jobs:
           echo "CMAKE_BUILD_PARALLEL_LEVEL=$CORES" >> $GITHUB_ENV
           echo "CTEST_PARALLEL_LEVEL=$CORES" >> $GITHUB_ENV
 
-      - name: Build without getlibs
-        run: |
-          BUILD=build-${TARGET}-${CMAKE_BUILD_TYPE,,}
-          cmake -S . -B "$BUILD"
-          cmake --build "$BUILD" --config $CMAKE_BUILD_TYPE
-          ctest --test-dir "$BUILD" -C $CMAKE_BUILD_TYPE
-      - name: Get dependencies
+      - name: Get Libs
         run: |
           CMAKE_BUILD_TYPE=Release ./getlibs.sh $TARGET
-      - name: Build with getlibs
+      - name: Build
         run: |
-          BUILD=build-${TARGET}-libs-${CMAKE_BUILD_TYPE,,}
-          cmake -S . -B "$BUILD" -DCMAKE_PREFIX_PATH="$PWD/local/$TARGET" -DFIND_FATAL=ON
+          BUILD=build-${TARGET}-${CMAKE_BUILD_TYPE,,}
+          cmake -S . -B "$BUILD" -DCMAKE_PREFIX_PATH="$PWD/local/${TARGET}" -DFIND_FATAL=ON
           cmake --build "$BUILD" --config $CMAKE_BUILD_TYPE
           ctest --test-dir "$BUILD" -C $CMAKE_BUILD_TYPE
 
@@ -106,18 +94,12 @@ jobs:
           CORES=$(sysctl -n hw.ncpu)
           echo "CMAKE_BUILD_PARALLEL_LEVEL=$CORES" >> $GITHUB_ENV
           echo "CTEST_PARALLEL_LEVEL=$CORES" >> $GITHUB_ENV
-      - name: Build without getlibs
-        run: |
-          BUILD=build-${TARGET}-$(tr '[:upper:]' '[:lower:]' <<< "$CMAKE_BUILD_TYPE")
-          cmake -S . -B "$BUILD"
-          cmake --build "$BUILD" --config $CMAKE_BUILD_TYPE
-          ctest --test-dir "$BUILD" -C $CMAKE_BUILD_TYPE
-      - name: Get dependencies
+      - name: Get Libs
         run: |
           CMAKE_BUILD_TYPE=Release ./getlibs.sh $TARGET
       - name: Build with getlibs
         run: |
-          BUILD=build-${TARGET}-libs-$(tr '[:upper:]' '[:lower:]' <<< "$CMAKE_BUILD_TYPE")
+          BUILD=build-${TARGET}-debug
           cmake -S . -B "$BUILD" -DCMAKE_PREFIX_PATH="$PWD/local/x86_64-darwin" -DFIND_FATAL=ON
           cmake --build "$BUILD" --config $CMAKE_BUILD_TYPE
           ctest --test-dir "$BUILD" -C $CMAKE_BUILD_TYPE
@@ -132,20 +114,14 @@ jobs:
       CTEST_OUTPUT_ON_FAILURE: 1
     steps:
       - uses: actions/checkout@v4
-      - name: Build without getlibs
-        run: |
-          $env:BUILD='build-x86_64-windows-debug'
-          cmake -S . -B $env:BUILD
-          cmake --build $env:BUILD --config $env:CMAKE_BUILD_TYPE
-          ctest --test-dir $env:BUILD -C $env:CMAKE_BUILD_TYPE
-      - name: Get dependencies
+      - name: Get Libs
         run: |
           vcpkg integrate install
           vcpkg install doctest --triplet x64-windows
           pwsh -Command { $env:CMAKE_BUILD_TYPE=Release; bash ./getlibs.sh x86_64-w64-mingw32 }
-      - name: Build with getlibs
+      - name: Build
         run: |
-          $env:BUILD='build-x86_64-windows-libs-debug'
+          $env:BUILD=build-x86_64-windows-debug'
           cmake -S . -B $env:BUILD -DCMAKE_PREFIX_PATH=${{ github.workspace }}/local/x86_64-w64-mingw32
           cmake --build $env:BUILD --config $env:CMAKE_BUILD_TYPE
           ctest --test-dir $env:BUILD -C $env:CMAKE_BUILD_TYPE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.23)
 cmake_policy(SET CMP0048 NEW) # project() command manages VERSION variables
 project(UUtils VERSION 2.0.6 HOMEPAGE_URL "https://github.com/UPPAALModelChecker/UUtils" LANGUAGES CXX C)
 include(CMakePackageConfigHelpers)

--- a/cmake/toolchain/arm64-darwin.cmake
+++ b/cmake/toolchain/arm64-darwin.cmake
@@ -1,0 +1,16 @@
+# the name of the target operating system
+set(CMAKE_SYSTEM_NAME Darwin)
+
+set(CMAKE_C_COMPILER cc)
+set(CMAKE_CXX_COMPILER c++)
+
+# where is the target environment located
+set(CMAKE_FIND_ROOT_PATH "${CMAKE_PREFIX_PATH}")
+
+# adjust the default behavior of the FIND_XXX() commands:
+# search programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH)
+
+# search headers and libraries in the target environment
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/compile.sh
+++ b/compile.sh
@@ -58,8 +58,8 @@ for target in $targets ; do
     unset CMAKE_PREFIX_PATH
     unset CMAKE_BUILD_TYPE
     unset BUILD_TARGET
-    unset BUILD_SUFFIX
-    unset BUILD_EXTRA
+    BUILD_SUFFIX=""
+    BUILD_EXTRA=""
     case "$target" in
         x86_64-linux-gcc10*)
             BUILD_TARGET=x86_64-linux-gcc10
@@ -102,7 +102,7 @@ for target in $targets ; do
     fi
     CMAKE_BUILD_TYPE=Release "$PROJECT_DIR/getlibs.sh" "$BUILD_TARGET"
     export CMAKE_PREFIX_PATH="$PROJECT_DIR/local/$BUILD_TARGET"
-    BUILD_EXTRA="-DFIND_FATAL=ON ${BUILD_EXTRA+x}"
+    BUILD_EXTRA="-DFIND_FATAL=ON ${BUILD_EXTRA}"
     case "$target" in
         *-ubsan*)
             BUILD_SUFFIX="${BUILD_SUFFIX}-ubsan"
@@ -133,7 +133,7 @@ for target in $targets ; do
                 export CMAKE_BUILD_TYPE=Debug
             fi
     esac
-    BUILD_DIR="build-${BUILD_TARGET}${BUILD_SUFFIX+x}-${CMAKE_BUILD_TYPE,,}"
+    BUILD_DIR="build-${BUILD_TARGET}${BUILD_SUFFIX}-${CMAKE_BUILD_TYPE,,}"
     echo "COMPILE for $target in $BUILD_DIR using $BUILD_EXTRA"
     show_cmake_vars
     cmake -S "$PROJECT_DIR" -B "$BUILD_DIR" $BUILD_EXTRA

--- a/compile.sh
+++ b/compile.sh
@@ -1,82 +1,108 @@
 #!/usr/bin/env bash
-set -e
-
-if [ $# -eq 0 ] ; then
-  echo "Script $0 compiles this library for a set of targets specified as arguments."
-  echo "Possible targets:"
-  echo "  linux64|x86_64-linux - targets are compiled on Linux assuming cmake, ninja/make, gcc and g++ installed."
-  echo "  win64|x86_64-w64-mingw32 - targets are cross-compiled on Linux assuming cmake, ninja/make, MinGW and Wine installed."
-  echo "  macos64|x86_64-darwin - targets are compiled on MacOS assuming cmake, ninja/make, gcc and g++ are installed."
-  echo "Possible target suffixes (append to the target making one word):"
-  echo "  -libs - build with dependent libraries to be installed by getlib.sh"
-  echo "  -ubsan - build with undefined behavior sanitizer (may break benchmarks with g++-13)"
-  echo "  -lsan - build with memory leak sanitizer (expect test_new to fail as it leaks on purpose)"
-  echo "  -asan - build with address sanitizer (expect test_new to fail as it leaks on purpose)"
-  echo "  -debug/-release - build either with debug information or optimized for release"
-  echo "For example, build linux64 release with getlibs and undefined behavior sanitizer:"
-  echo "  $0 linux64-libs-ubsan-release"
-  echo "The script is sensitive to CMAKE_BUILD_TYPE and other environment variables"
-  machine=$(uname -m)
-  kernel=$(uname -s)
-  targets="${machine,,}-${kernel,,}-libs-release"
-  if [ -n "$(command -v x86_64-w64-mingw32-g++)" ]; then
-    targets="$targets x86_64-w64-mingw32-libs-release"
-  fi
-  echo "Guessing: $targets"
-else
-  targets="$@"
-fi
+set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+function show_toolchains() {
+    for toolchain_file in "$PROJECT_DIR/cmake/toolchain"/* ; do
+        toolchain=$(basename $toolchain_file)
+        echo "  ${toolchain%.cmake}"
+    done
+}
+
+function show_help() {
+    echo "Script $0 compiles this library for a set of target platforms specified as arguments."
+    echo "Possible targets:"
+    show_toolchains
+    echo "Possible target suffixes (append to the target making one word):"
+    echo "  -ubsan - build with undefined behavior sanitizer (may break benchmarks with g++-13)"
+    echo "  -lsan - build with memory leak sanitizer (expect test_new to fail as it leaks on purpose)"
+    echo "  -asan - build with address sanitizer (expect test_new to fail as it leaks on purpose)"
+    echo "  -debug/-release - build either with debug information or optimized for release"
+    echo "For example, build linux64 release with undefined behavior sanitizer:"
+    echo "  $0 x64_86-linux-ubsan-release"
+    echo "The script is sensitive to CMAKE_BUILD_TYPE and other environment variables"
+}
+
+if [ $# -eq 0 ] ; then
+    show_help
+    machine=$(uname -m)
+    kernel=$(uname -s)
+    targets="${machine,,}-${kernel,,}-release"
+    if [ -n "$(command -v x86_64-w64-mingw32-g++)" ]; then
+        targets="$targets x86_64-w64-mingw32-release"
+    fi
+    echo "Guessing: $targets"
+else
+    case "$1" in
+        -h|--help|help)
+            show_help
+            exit 1
+            ;;
+    esac
+    targets="$@"
+fi
+
+if [ -n "${CMAKE_TOOLCHAIN_FILE+x}" ]; then
+   TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN_FILE"
+fi
+
+function show_cmake_vars() {
+    for var in CMAKE_TOOLCHAIN_FILE CMAKE_BUILD_TYPE CMAKE_PREFIX_PATH CMAKE_INSTALL_PREFIX \
+               CMAKE_GENERATOR CMAKE_BUILD_PARALLEL_LEVEL; do
+        echo "  $var=${!var:- (unset)}"
+    done
+}
+
 for target in $targets ; do
-    unset CMAKE_TOOLCHAIN_FILE
     unset CMAKE_PREFIX_PATH
     unset CMAKE_BUILD_TYPE
     unset BUILD_TARGET
     unset BUILD_SUFFIX
     unset BUILD_EXTRA
     case "$target" in
-        linux64-gcc10*|x86_64-linux-gcc10*)
+        x86_64-linux-gcc10*)
             BUILD_TARGET=x86_64-linux-gcc10
             ;;
-        linux64*|x86_64-linux*)
+        x86_64-linux*)
             BUILD_TARGET=x86_64-linux
             ;;
-        linux32-gcc10*|i686-linux-gcc10*)
+        i686-linux-gcc10*)
             BUILD_TARGET=i686-linux-gcc10
             ;;
-        linux32*|i686-linux*)
+        i686-linux*)
             BUILD_TARGET=i686-linux
             ;;
-        win64*|x86_64-w64-mingw32*)
+        x86_64-w64-mingw32*)
             BUILD_TARGET=x86_64-w64-mingw32
-            [ -n "$WINEPATH" ] || export WINEPATH=$("$PROJECT_DIR"/winepath-for $BUILD_TARGET)
+            export WINEPATH=$("$PROJECT_DIR"/winepath-for $BUILD_TARGET)
             ;;
-        win32*|i686-w64-mingw32*)
+        i686-w64-mingw32*)
             BUILD_TARGET=i686-w64-mingw32
-            [ -n "$WINEPATH" ] || export WINEPATH=$("$PROJECT_DIR"/winepath-for $BUILD_TARGET)
+            export WINEPATH=$("$PROJECT_DIR"/winepath-for $BUILD_TARGET)
             ;;
-        macos64-brew-gcc10-*|darwin-brew-gcc10-*|x86_64-darwin-brew-gcc10-*)
+        x86_64-darwin-brew-gcc10-*)
             BUILD_TARGET=x86_64-darwin-brew-gcc10
             ;;
-        macos*|darwin*|x86_64-darwin*)
+        x86_64-darwin*)
+            BUILD_TARGET=x86_64-darwin
+            ;;
+        arm64-darwin*)
             BUILD_TARGET=x86_64-darwin
             ;;
         *)
             echo "Failed to recognize target platform: $target"
+            echo "Possible targets:"
+            show_toolchains
             exit 1
             ;;
     esac
-    [ -z "$BUILD_TARGET" ] || export CMAKE_TOOLCHAIN_FILE="$PROJECT_DIR/cmake/toolchain/${BUILD_TARGET}.cmake"
-    case "$target" in
-        *-lib*)
-            CMAKE_BUILD_TYPE=Release "$PROJECT_DIR/getlibs.sh" "$BUILD_TARGET"
-            export CMAKE_PREFIX_PATH="$PROJECT_DIR/local/$BUILD_TARGET"
-            BUILD_SUFFIX="-libs"
-            BUILD_EXTRA="-DFIND_FATAL=ON ${BUILD_EXTRA}"
-            ;;
-    esac
+    if [ -z "${TOOLCHAIN_FILE+x}" ] && [ -r "$PROJECT_DIR/cmake/toolchain/${BUILD_TARGET}.cmake" ]; then
+        export CMAKE_TOOLCHAIN_FILE="$PROJECT_DIR/cmake/toolchain/${BUILD_TARGET}.cmake"
+    fi
+    CMAKE_BUILD_TYPE=Release "$PROJECT_DIR/getlibs.sh" "$BUILD_TARGET"
+    export CMAKE_PREFIX_PATH="$PROJECT_DIR/local/$BUILD_TARGET"
+    BUILD_EXTRA="-DFIND_FATAL=ON ${BUILD_EXTRA+x}"
     case "$target" in
         *-ubsan*)
             BUILD_SUFFIX="${BUILD_SUFFIX}-ubsan"
@@ -103,16 +129,13 @@ for target in $targets ; do
             export CMAKE_BUILD_TYPE=Release
             ;;
         *)
-            if [ -z "$CMAKE_BUILD_TYPE" ]; then
+            if [ -z "${CMAKE_BUILD_TYPE+x}" ]; then
                 export CMAKE_BUILD_TYPE=Debug
             fi
     esac
-    BUILD_DIR="build-${BUILD_TARGET}${BUILD_SUFFIX}-${CMAKE_BUILD_TYPE,,}"
+    BUILD_DIR="build-${BUILD_TARGET}${BUILD_SUFFIX+x}-${CMAKE_BUILD_TYPE,,}"
     echo "COMPILE for $target in $BUILD_DIR using $BUILD_EXTRA"
-    echo "  CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE:-(unset)}"
-    echo "  CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-(unset)}"
-    echo "  CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-(unset)}"
-    echo "  CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-(unset)}"
+    show_cmake_vars
     cmake -S "$PROJECT_DIR" -B "$BUILD_DIR" $BUILD_EXTRA
     cmake --build "$BUILD_DIR" --config $CMAKE_BUILD_TYPE
     (cd "$BUILD_DIR" ; ctest -C $CMAKE_BUILD_TYPE --output-on-failure)

--- a/getlibs.sh
+++ b/getlibs.sh
@@ -2,27 +2,51 @@
 #set -euxo pipefail
 set -euo pipefail
 
-if [ $# -eq 0 ] ; then
-  echo "Script $0 compiles and installs dependent libraries for a set of targets specified as arguments."
-  echo "Possible arguments:"
-  echo "  linux64 win64 macos64"
-  echo "The script is sensitive to CMake environment variables like:"
-  echo "  CMAKE_TOOLCHAIN_FILE CMAKE_BUILD_TYPE CMAKE_PREFIX_PATH"
-  machine=$(uname -m)
-  kernel=$(uname -s)
-  targets=${machine,,}-${kernel,,}
-  echo "Guessing target: $targets"
-else
-  targets="$@"
-fi
-
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+function show_help() {
+    echo "Script $0 compiles and installs dependent libraries for a set of target platforms specified as arguments."
+    echo "Possible arguments:"
+    for toolchain_file in "$PROJECT_DIR/cmake/toolchain"/* ; do
+        toolchain=$(basename $toolchain_file)
+        echo "  ${toolchain%.cmake}"
+    done
+    echo "The script is sensitive to CMake environment variables like:"
+    echo "  CMAKE_TOOLCHAIN_FILE CMAKE_BUILD_TYPE CMAKE_PREFIX_PATH"
+}
+
+if [ $# -eq 0 ] ; then
+    show_help
+    machine=$(uname -m)
+    kernel=$(uname -s)
+    targets=${machine,,}-${kernel,,}
+    echo "Guessing target: $targets"
+else
+    case "$1" in
+        -h|--help|help)
+            show_help
+            exit 1
+            ;;
+    esac
+    targets="$@"
+fi
 
 if [ -z "${CMAKE_BUILD_TYPE+x}" ]; then
     export CMAKE_BUILD_TYPE=Release
 elif [ "$CMAKE_BUILD_TYPE" != Release ]; then
     echo "WARNING: building libs with CMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE"
 fi
+
+if [ -n "${CMAKE_TOOLCHAIN_FILE+x}" ]; then
+   TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN_FILE"
+fi
+
+function show_cmake_vars() {
+    for var in CMAKE_TOOLCHAIN_FILE CMAKE_BUILD_TYPE CMAKE_PREFIX_PATH CMAKE_INSTALL_PREFIX \
+               CMAKE_GENERATOR CMAKE_BUILD_PARALLEL_LEVEL; do
+        echo "  $var=${!var:- (unset)}"
+    done
+}
 
 for target in $targets ; do
     echo "GETLIBS for $target"
@@ -32,6 +56,9 @@ for target in $targets ; do
     PREFIX="$PROJECT_DIR/local/${BUILD_TARGET}"
     # export CMAKE_PREFIX_PATH="$PREFIX"
     export CMAKE_INSTALL_PREFIX="$PREFIX"
+    if [ -z "${TOOLCHAIN_FILE+x}" ] && [ -r "$PROJECT_DIR/cmake/toolchain/${target}.cmake" ] ; then
+        export CMAKE_TOOLCHAIN_FILE="$PROJECT_DIR/cmake/toolchain/${target}.cmake"
+    fi
 
     ## XXHASH
     NAME=xxHash
@@ -50,10 +77,7 @@ for target in $targets ; do
         [ -d "$SOURCE" ] || tar xf "${ARCHIVE}"
         popd
         echo "Building $LIBRARY in $BUILD from $SOURCE"
-        echo "  CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE:-(unset)}"
-        echo "  CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-(unset)}"
-        echo "  CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-(unset)}"
-        echo "  CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-(unset)}"
+        show_cmake_vars
         cmake -S "$SOURCE/cmake_unofficial" -B "$BUILD" -DBUILD_SHARED_LIBS=OFF
         cmake --build "$BUILD" --config $CMAKE_BUILD_TYPE
         cmake --install "$BUILD" --config $CMAKE_BUILD_TYPE --prefix "${CMAKE_INSTALL_PREFIX}"
@@ -73,19 +97,15 @@ for target in $targets ; do
         echo "$LIBRARY is already installed in $CMAKE_INSTALL_PREFIX"
     else
         pushd "$SOURCES"
-        [ -r "$ARCHIVE" ] || curl -sL "https://github.com/boostorg/boost/releases/download/${LIBRARY}/${LIBRARY}-cmake.tar.xz" -o "$ARCHIVE"
+        [ -r "${ARCHIVE}" ] || curl -sL "https://github.com/boostorg/boost/releases/download/${LIBRARY}/${ARCHIVE}" -o "${ARCHIVE}"
         if [ -n "$(command -v sha256sum)" ]; then echo "$SHA256 $ARCHIVE" | sha256sum --check ; fi
-        [ -d "$SOURCE" ] || tar xf "$ARCHIVE"
+        [ -d "${SOURCE}" ] || tar xf "${ARCHIVE}"
         popd
         echo "Building $LIBRARY in $BUILD from $SOURCE"
-        echo "  CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE:-(unset)}"
-        echo "  CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-(unset)}"
-        echo "  CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-(unset)}"
-        echo "  CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-(unset)}"
+        show_cmake_vars
         cmake -S "$SOURCE" -B "$BUILD" -DBUILD_SHARED_LIBS=OFF \
           -DBOOST_INCLUDE_LIBRARIES="headers;math" -DBOOST_ENABLE_MPI=OFF -DBOOST_ENABLE_PYTHON=OFF \
-          -DBOOST_RUNTIME_LINK=static -DBUILD_TESTING=OFF -DBOOST_USE_STATIC_LIBS=ON -DBOOST_USE_DEBUG_LIBS=ON \
-          -DBOOST_USE_RELEASE_LIBS=ON -DBOOST_USE_STATIC_RUNTIME=ON -DBOOST_INSTALL_LAYOUT=system -DBOOST_ENABLE_CMAKE=ON
+          -DBOOST_RUNTIME_LINK=static -DBUILD_TESTING=OFF -DBOOST_INSTALL_LAYOUT=system
         cmake --build "$BUILD" --config $CMAKE_BUILD_TYPE
         cmake --install "$BUILD" --config $CMAKE_BUILD_TYPE --prefix "${CMAKE_INSTALL_PREFIX}"
         rm -Rf "$BUILD"
@@ -109,10 +129,7 @@ for target in $targets ; do
         [ -d "${SOURCE}" ] || tar xf "${ARCHIVE}"
         popd
         echo "Building $LIBRARY in $BUILD from $SOURCE"
-        echo "  CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE:-(unset)}"
-        echo "  CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-(unset)}"
-        echo "  CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-(unset)}"
-        echo "  CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-(unset)}"
+        show_cmake_vars
         cmake -S "$SOURCE" -B "$BUILD" -DDOCTEST_WITH_TESTS=OFF -DDOCTEST_WITH_MAIN_IN_STATIC_LIB=ON
         cmake --build "$BUILD" --config $CMAKE_BUILD_TYPE
         cmake --install "$BUILD" --config $CMAKE_BUILD_TYPE --prefix "${CMAKE_INSTALL_PREFIX}"
@@ -122,10 +139,10 @@ for target in $targets ; do
 
     ## Google Benchmark
     NAME=benchmark
-    VERSION=1.9.0 # v1.8.2 fails with "-lrt not found" on win64
+    VERSION=1.9.1 # v1.8.2 fails with "-lrt not found" on win64, v1.8.3 is good
     LIBRARY="${NAME}-${VERSION}"
     ARCHIVE="${LIBRARY}.tar.gz"
-    SHA256=35a77f46cc782b16fac8d3b107fbfbb37dcd645f7c28eee19f3b8e0758b48994
+    SHA256=32131c08ee31eeff2c8968d7e874f3cb648034377dfc32a4c377fa8796d84981
     SOURCE="${SOURCES}/${LIBRARY}"
     BUILD="${PREFIX}/build-${LIBRARY}"
     if [ -r "${CMAKE_INSTALL_PREFIX}/include/benchmark/benchmark.h" ] ; then
@@ -137,10 +154,7 @@ for target in $targets ; do
         [ -d "$LIBRARY" ] || tar -xf "$ARCHIVE"
         popd
         echo "Building $LIBRARY in $BUILD from $SOURCE"
-        echo "  CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE:-(unset)}"
-        echo "  CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-(unset)}"
-        echo "  CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-(unset)}"
-        echo "  CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-(unset)}"
+        show_cmake_vars
         cmake -S "$SOURCE" -B "$BUILD" -DBUILD_SHARED_LIBS=OFF \
           -DBENCHMARK_ENABLE_TESTING=OFF -DBENCHMARK_ENABLE_EXCEPTIONS=ON -DBENCHMARK_ENABLE_LTO=OFF \
           -DBENCHMARK_USE_LIBCXX=OFF -DBENCHMARK_ENABLE_WERROR=ON -DBENCHMARK_FORCE_WERROR=OFF

--- a/test/debug/CMakeLists.txt
+++ b/test/debug/CMakeLists.txt
@@ -15,13 +15,19 @@ add_test(NAME debug_utils_50 COMMAND test_utils 50)  # failing test: L64-debug
 
 # mark tests which are supposed to fail
 set_tests_properties(
-  debug_new_2
+  debug_new_2 # test for crash
   debug_utils_10
   debug_utils_20
   debug_utils_1
   debug_utils_7
   debug_utils_50
   PROPERTIES WILL_FAIL TRUE)
+
+if (ASAN OR LSAN)
+  set_tests_properties(
+    debug_new_1 # test for memory leaks
+    PROPERTIES WILL_FAIL TRUE)
+endif()
 
 # disable failing tests:
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")


### PR DESCRIPTION
- [x] Removed CI builds without getlibs (cmake is too unstable to maintain and the development load is too high to have all libraries available from scratch)
- [x] boost-1.86
- [x] GoogleBenchmark-1.9.1
- [x] Cleaned up getlibs.sh and compile.sh
- [x] Upgraded CI to ubuntu-24.04 explicitly (ubuntu-latest seems to have switched back to ubuntu-22.04)
- [x] Require CMake-2.23 for `FILE_SET` and other install export features to work correctly.